### PR TITLE
Make cave generator more lenient

### DIFF
--- a/src/main/java/fluke/worleycaves/config/Configs.java
+++ b/src/main/java/fluke/worleycaves/config/Configs.java
@@ -58,6 +58,10 @@ public class Configs
 		@Config.Comment({"Air blocks at or below this y level will generate as lavaBlock", "Default: 10"})
 		@Config.RequiresWorldRestart
 		public int lavaDepth = 10;
+
+		@Config.Comment({"Allow replacing more blocks with caves (useful for mods which completely overwrite world gen)"})
+		@Config.RequiresWorldRestart
+		public boolean allowReplaceMoreBlocks = true;
 	}
 	
 	@SubscribeEvent

--- a/src/main/java/fluke/worleycaves/world/WorleyCaveGenerator.java
+++ b/src/main/java/fluke/worleycaves/world/WorleyCaveGenerator.java
@@ -425,6 +425,13 @@ public class WorleyCaveGenerator extends MapGenCaves
         if (biome == net.minecraft.init.Biomes.DESERT) return true;
         return false;
     }
+
+    @Override
+    protected boolean canReplaceBlock(IBlockState state, IBlockState stateUp)
+    {
+        // Need to be able to replace not just vanilla stone + stuff
+        return (Configs.cavegen.allowReplaceMoreBlocks && state.getMaterial() == Material.ROCK) || super.canReplaceBlock(state, stateUp);
+    }
     
     /**
      * Digs out the current block, default implementation removes stone, filler, and top block


### PR DESCRIPTION
This makes a slight modification to the cave generator, by allowing it to replace any rock type blocks, and not just the hardcoded list of blocks in vanilla. I've also added a config option so the original behavior can be restored, if need be.

This would make Worley Caves work out of the box with TFC, as TFC's underground uses custom rock blocks, so worley caves normally won't be able to carve through them.